### PR TITLE
Adjust auto-generate penalty

### DIFF
--- a/index.html
+++ b/index.html
@@ -770,7 +770,7 @@ let levelProcessed = false; // Prevent double counting
 let totalBlocks = 0; // Track total blocks removed
 let chainCount = 0; // Track chain count for cascading sound effects
 let totalChainBlocks = 0; // Track total blocks in current chain
-const AUTO_GENERATE_PENALTY = 50; // Points deducted when auto-generating a tile
+const AUTO_GENERATE_PENALTY = 500; // Points deducted when auto-generating a tile
 
 // Audio context for sound effects
 let audioContext;
@@ -1851,7 +1851,7 @@ function generateTileForColor(color) {
   boardElements[position.y][position.x] = createTile(position.x, position.y, color);
   
   // Deduct points instead of using a move
-  gameScore = Math.max(0, gameScore - AUTO_GENERATE_PENALTY);
+  gameScore -= AUTO_GENERATE_PENALTY;
   updateUI();
   
   // Show message


### PR DESCRIPTION
## Summary
- increase missing color auto-generate penalty
- allow score to go negative when auto-generating a block

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688acd6f5648832c8339cf9470299f6f