### PR TITLE
Adjust auto-generate penalty

### DIFF
--- a/index.html
+++ b/index.html
@@ -783,7 +783,7 @@ let totalBlocks = 0; // Track total blocks removed
 let chainCount = 0; // Track chain count for cascading sound effects
 let totalChainBlocks = 0; // Track total blocks in current chain
 let shuffleCost = 1; // Cost for using Reset Position, increases each use
-const AUTO_GENERATE_PENALTY = 500; // Points deducted when auto-generating a tile
+const AUTO_GENERATE_PENALTY = 50; // Points deducted when auto-generating a tile
 
 // Audio context for sound effects
 let audioContext;


### PR DESCRIPTION
## Summary
- lower `AUTO_GENERATE_PENALTY` to 50 so only 50 points are deducted when auto generating blocks
- negative scores are preserved without clipping

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688ad5b4eb64832c9d9d597ca0920d13