### PR TITLE
Adjust score panel sizes

### DIFF
--- a/index.html
+++ b/index.html
@@ -641,6 +641,7 @@
     .score-box {
       padding: 0.5rem 0.6rem;
       font-size: 0.7rem;
+      height: 100px;
     }
     
     .action-buttons {
@@ -720,12 +721,12 @@
   
   /* Make moves counter larger since it's more important */
   #moves {
-    font-size: 1.2em;
+    font-size: 1.6em;
     font-weight: bold;
   }
 
   #score {
-    font-size: 1em;
+    font-size: 1.4em;
     font-weight: bold;
   }
 </style>


### PR DESCRIPTION
## Summary
- make `score-box` height match the logo on mobile
- enlarge the moves and score counters

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ad7e9beb4832c83415db283a0c9e0