### PR TITLE
Add score-to-board animation on penalty tiles

### DIFF
--- a/index.html
+++ b/index.html
@@ -1999,6 +1999,45 @@ function animateTileToScore(tile) {
   }, 500);
 }
 
+// Animate a tile flying from the score box to the board
+function animateScoreToTile(color, pos, cb) {
+  const tileContainer = document.querySelector('.tile-container');
+  const gameContainer = document.querySelector('.game-container');
+  const containerRect = gameContainer.getBoundingClientRect();
+  const containerSize = Math.min(containerRect.width, containerRect.height) - 32;
+  const tileSize = (containerSize - (SIZE-1) * 8) / SIZE;
+  const gap = 8;
+
+  const temp = document.createElement('div');
+  temp.className = `tile tile-${color}`;
+  temp.style.width = `${tileSize}px`;
+  temp.style.height = `${tileSize}px`;
+  temp.style.lineHeight = `${tileSize}px`;
+  temp.style.fontSize = `${Math.min(tileSize * 0.6, 28)}px`;
+
+  const scoreRect = scoreBox.getBoundingClientRect();
+  const containerOffset = tileContainer.getBoundingClientRect();
+  const startX = scoreRect.left + scoreRect.width/2 - containerOffset.left - tileSize/2;
+  const startY = scoreRect.top + scoreRect.height/2 - containerOffset.top - tileSize/2;
+  const endX = pos.x * (tileSize + gap);
+  const endY = pos.y * (tileSize + gap);
+
+  temp.style.transform = `translate(${startX}px, ${startY}px) scale(0.3) rotate(-45deg)`;
+  temp.style.opacity = '0';
+  tileContainer.appendChild(temp);
+
+  requestAnimationFrame(() => {
+    temp.style.transition = 'transform 0.5s cubic-bezier(0.22,1,0.36,1), opacity 0.5s ease-out';
+    temp.style.opacity = '1';
+    temp.style.transform = `translate(${endX}px, ${endY}px) scale(1) rotate(0deg)`;
+  });
+
+  setTimeout(() => {
+    if (temp.parentNode) temp.parentNode.removeChild(temp);
+    if (cb) cb();
+  }, 500);
+}
+
 // Check lonely tiles and auto-generate
 function checkAndGenerateLonelyTiles() {
   // Count each color
@@ -2050,9 +2089,11 @@ function generateTileForColor(color) {
   const randomIndex = Math.floor(Math.random() * emptyPositions.length);
   const position = emptyPositions[randomIndex];
   
-  // Generate new tile
+  // Reserve position in matrix and animate from score box
   boardMatrix[position.y][position.x] = color;
-  boardElements[position.y][position.x] = createTile(position.x, position.y, color);
+  animateScoreToTile(color, position, () => {
+    boardElements[position.y][position.x] = createTile(position.x, position.y, color);
+  });
   
   // Deduct points instead of using a move
   gameScore -= AUTO_GENERATE_PENALTY;


### PR DESCRIPTION
## Summary
- add `animateScoreToTile` helper
- use the helper when lonely tile penalty occurs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688cc4e06d2c832c8fc517f1595bf57b