### PR TITLE
Raise z-index for flying tiles

### DIFF
--- a/index.html
+++ b/index.html
@@ -1977,6 +1977,7 @@ function createParticleExplosion(tile, x, y) {
 
 // Animate removed tile flying toward the score box
 function animateTileToScore(tile) {
+  tile.style.zIndex = '25';
   const scoreRect = scoreBox.getBoundingClientRect();
   const tileRect = tile.getBoundingClientRect();
   const dx = scoreRect.left + scoreRect.width / 2 - (tileRect.left + tileRect.width / 2);
@@ -2010,6 +2011,7 @@ function animateScoreToTile(color, pos, cb) {
 
   const temp = document.createElement('div');
   temp.className = `tile tile-${color}`;
+  temp.style.zIndex = '25';
   temp.style.width = `${tileSize}px`;
   temp.style.height = `${tileSize}px`;
   temp.style.lineHeight = `${tileSize}px`;


### PR DESCRIPTION
## Summary
- ensure flying tile animations appear above other tiles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688cc9639c68832caf5dff4110279740