### PR TITLE
Enhance penalty animations and add invalid move feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -396,7 +396,7 @@
     width: 90px; 
     height: 90px; 
     border-radius: 12px; 
-    transition: all 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
+    transition: transform 250ms cubic-bezier(0.25, 0.8, 0.5, 1), filter 250ms ease;
     text-align: center;
     font-weight: 700;
     font-size: 55px;
@@ -759,10 +759,19 @@
   #scoreBox.penalty-flash {
     animation: penalty-flash 0.6s ease;
   }
+  #scoreBox.penalty-pop {
+    animation: penalty-pop 0.6s ease;
+  }
 
   @keyframes penalty-flash {
     0%,100% { background: linear-gradient(135deg, #ffb3b3 0%, #e06666 100%); }
     50% { background: linear-gradient(135deg, #ff6666 0%, #cc0000 100%); }
+  }
+  @keyframes penalty-pop {
+    0% { transform: scale(1); }
+    40% { transform: scale(1.15); }
+    70% { transform: scale(0.9); }
+    100% { transform: scale(1); }
   }
 
   .footer-links {
@@ -817,6 +826,32 @@
     text-decoration: none;
     font-size: 1.2rem;
     color: #6b4e3d;
+  }
+
+  .tile-container.bounce-left { animation: bounce-left 0.3s ease; }
+  .tile-container.bounce-right { animation: bounce-right 0.3s ease; }
+  .tile-container.bounce-up { animation: bounce-up 0.3s ease; }
+  .tile-container.bounce-down { animation: bounce-down 0.3s ease; }
+
+  @keyframes bounce-left {
+    0% { transform: translateX(0); }
+    50% { transform: translateX(-15px); }
+    100% { transform: translateX(0); }
+  }
+  @keyframes bounce-right {
+    0% { transform: translateX(0); }
+    50% { transform: translateX(15px); }
+    100% { transform: translateX(0); }
+  }
+  @keyframes bounce-up {
+    0% { transform: translateY(0); }
+    50% { transform: translateY(-15px); }
+    100% { transform: translateY(0); }
+  }
+  @keyframes bounce-down {
+    0% { transform: translateY(0); }
+    50% { transform: translateY(15px); }
+    100% { transform: translateY(0); }
   }
 </style>
 </head>
@@ -1006,6 +1041,10 @@ function playMoveSound() {
   playSound(200, 0.05, 'triangle', 0.06); // increased volume
 }
 
+function playInvalidMoveSound() {
+  playSound(120, 0.2, 'sawtooth', 0.15);
+}
+
 const movesEl          = document.getElementById('moves');
 const levelEl          = document.getElementById('level');
 const levelNameEl      = document.getElementById('levelName');
@@ -1020,9 +1059,21 @@ const overlayRestartBtn= document.getElementById('overlayRestartBtn');
 const instructionsDiv  = document.getElementById('instructions');
 const instructionsBtn  = document.getElementById('instructionsBtn');
 
+function triggerInvalidBounce(dir) {
+  const cls = dir.axis === 'x'
+    ? (dir.x > 0 ? 'bounce-right' : 'bounce-left')
+    : (dir.y > 0 ? 'bounce-down' : 'bounce-up');
+  tileContainer.classList.add(cls);
+  setTimeout(() => tileContainer.classList.remove(cls), 300);
+}
+
 function triggerPenaltyFlash() {
   scoreBox.classList.add("penalty-flash");
-  setTimeout(() => scoreBox.classList.remove("penalty-flash"), 600);
+  scoreBox.classList.add("penalty-pop");
+  setTimeout(() => {
+    scoreBox.classList.remove("penalty-flash");
+    scoreBox.classList.remove("penalty-pop");
+  }, 600);
 }
 
 function initGrid() {
@@ -1483,6 +1534,8 @@ function handleMove(direction) {
   }
   
   if (!canMove(dir)) {
+    playInvalidMoveSound();
+    triggerInvalidBounce(dir);
     return; // Don't deduct move if nothing shifts
   }
 
@@ -2047,18 +2100,20 @@ function animateScoreToTile(color, pos, cb) {
 
   temp.style.transform = `translate(${startX}px, ${startY}px) scale(0.3) rotate(-45deg)`;
   temp.style.opacity = '0';
+  temp.style.filter = 'brightness(1.5)';
   tileContainer.appendChild(temp);
 
   requestAnimationFrame(() => {
-    temp.style.transition = 'transform 0.5s cubic-bezier(0.22,1,0.36,1), opacity 0.5s ease-out';
+    temp.style.transition = 'transform 0.6s cubic-bezier(0.175,0.885,0.32,1.275), opacity 0.6s ease-out, filter 0.6s';
     temp.style.opacity = '1';
     temp.style.transform = `translate(${endX}px, ${endY}px) scale(1) rotate(0deg)`;
+    temp.style.filter = 'brightness(1)';
   });
 
   setTimeout(() => {
     if (temp.parentNode) temp.parentNode.removeChild(temp);
     if (cb) cb();
-  }, 500);
+  }, 600);
 }
 
 // Check lonely tiles and auto-generate
@@ -2085,8 +2140,8 @@ function checkAndGenerateLonelyTiles() {
   });
   
   // Generate new tile for each lonely color
-  lonelyColors.forEach(color => {
-    generateTileForColor(color);
+  lonelyColors.forEach((color, idx) => {
+    setTimeout(() => generateTileForColor(color), idx * 650);
   });
 }
 
@@ -2094,6 +2149,8 @@ function checkAndGenerateLonelyTiles() {
 function generateTileForColor(color) {
   // Check if moves remaining
   if (movesLeft <= 0) return;
+  if (isAnimating) return;
+  isAnimating = true;
   
   // Find all empty positions
   const emptyPositions = [];
@@ -2116,6 +2173,7 @@ function generateTileForColor(color) {
   boardMatrix[position.y][position.x] = color;
   animateScoreToTile(color, position, () => {
     boardElements[position.y][position.x] = createTile(position.x, position.y, color);
+    isAnimating = false;
   });
   
   // Deduct points instead of using a move


### PR DESCRIPTION
## Summary
- smooth tile movement with longer transition
- add penalty pop animation for score box
- show bounce effect and sound on invalid moves
- animate penalty tiles with brighter overshoot
- lock moves while penalty tile spawns

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688cdfdc94a0832c89aa85b7d5126c6f