### PR TITLE
Add penalty sound effect for auto-generated blocks

### DIFF
--- a/index.html
+++ b/index.html
@@ -1045,6 +1045,11 @@ function playInvalidMoveSound() {
   playSound(120, 0.2, 'sawtooth', 0.15);
 }
 
+function playPenaltySound() {
+  playSound(200, 0.15, 'sawtooth', 0.2);
+  setTimeout(() => playSound(120, 0.2, 'sawtooth', 0.2), 100);
+}
+
 const movesEl          = document.getElementById('moves');
 const levelEl          = document.getElementById('level');
 const levelNameEl      = document.getElementById('levelName');
@@ -1068,6 +1073,7 @@ function triggerInvalidBounce(dir) {
 }
 
 function triggerPenaltyFlash() {
+  playPenaltySound();
   scoreBox.classList.add("penalty-flash");
   scoreBox.classList.add("penalty-pop");
   setTimeout(() => {

--- a/itch.html
+++ b/itch.html
@@ -923,6 +923,11 @@ function playMoveSound() {
   playSound(200, 0.05, 'triangle', 0.06); // increased volume
 }
 
+function playPenaltySound() {
+  playSound(200, 0.15, 'sawtooth', 0.2);
+  setTimeout(() => playSound(120, 0.2, 'sawtooth', 0.2), 100);
+}
+
 const movesEl          = document.getElementById('moves');
 const levelEl          = document.getElementById('level');
 const levelNameEl      = document.getElementById('levelName');
@@ -1926,7 +1931,8 @@ function generateTileForColor(color) {
   // Deduct points instead of using a move
   gameScore -= AUTO_GENERATE_PENALTY;
   updateUI();
-  
+  playPenaltySound();
+
   // Show message
   showAutoGenerateMessage(color);
   


### PR DESCRIPTION
## Summary
- add penalty sound that plays when a new block is auto-generated and points are deducted
- hook the sound into penalty flash for main page and into penalty logic for itch build

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d70e656f4832cbb4a066ab78bc0d5