### PR TITLE
Highlight reset button when player is stuck

### DIFF
--- a/howtoplay.html
+++ b/howtoplay.html
@@ -4,6 +4,14 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>How to Play - RectBlox Game Guide</title>
+    <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png" />
+    <link rel="icon" type="image/png" sizes="192x192" href="android-chrome-192x192.png" />
+    <link rel="icon" type="image/png" sizes="512x512" href="android-chrome-512x512.png" />
+    <link rel="manifest" href="site.webmanifest" />
+    <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    <link rel="shortcut icon" href="favicon.ico" />
     <meta name="description" content="Learn how to play RectBlox! Complete game guide with tips, strategies, and rules for the match-3 block puzzle game.">
     <style>
         body {

--- a/index.html
+++ b/index.html
@@ -9,6 +9,9 @@
 <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png" />
 <link rel="manifest" href="site.webmanifest" />
 <link rel="icon" type="image/x-icon" href="favicon.ico" />
+<link rel="icon" type="image/png" sizes="192x192" href="android-chrome-192x192.png" />
+<link rel="icon" type="image/png" sizes="512x512" href="android-chrome-512x512.png" />
+<link rel="shortcut icon" href="favicon.ico" />
 
 <!-- SEO Meta Tags -->
 <meta name="description" content="Play RectBlox - Free online match-3 block puzzle game! 6 challenging levels, beautiful design, mobile-friendly. No download required. Start playing now!">
@@ -260,10 +263,24 @@
     top: -1.2rem;
     left: 50%;
     transform: translateX(-50%);
-    font-size: 0.7rem;
-    color: #a8926f;
+    font-size: 0.75rem;
+    color: #6b4e3d;
+    background: #fffbea;
+    padding: 0.2rem 0.5rem;
+    border-radius: 4px;
+    box-shadow: 0 0 10px rgba(212, 165, 116, 0.5);
     pointer-events: none;
     animation: pulse 2s infinite;
+  }
+
+  .shuffle-highlight {
+    animation: shuffle-glow 1s infinite;
+  }
+
+  @keyframes shuffle-glow {
+    0% { box-shadow: 0 0 0 0 rgba(255, 215, 0, 0.4); transform: scale(1); }
+    50% { box-shadow: 0 0 20px 5px rgba(255, 215, 0, 0.9); transform: scale(1.05); }
+    100% { box-shadow: 0 0 0 0 rgba(255, 215, 0, 0.4); transform: scale(1); }
   }
 
   button {
@@ -963,7 +980,7 @@
       <div class="action-buttons">
         <button class="secondary-button" id="shuffleBtn">
           Reset Position
-          <div id="shuffleTip" class="shuffle-tip">Stuck? Try Reset Position!</div>
+          <div id="shuffleTip" class="shuffle-tip">👉 Stuck? Reset Position!</div>
         </button>
         <div class="level-info">Level <span id="level">1</span>: <span id="levelName">Easy Level</span></div>
         <button class="secondary-button" id="restartBtn">Restart</button>
@@ -1249,10 +1266,12 @@ function updateUI() {
 
 function showShuffleTip() {
   document.getElementById('shuffleTip').style.display = 'block';
+  document.getElementById('shuffleBtn').classList.add('shuffle-highlight');
 }
 
 function hideShuffleTip() {
   document.getElementById('shuffleTip').style.display = 'none';
+  document.getElementById('shuffleBtn').classList.remove('shuffle-highlight');
 }
 
 function nextLevel() {

--- a/index_backup.html
+++ b/index_backup.html
@@ -9,6 +9,9 @@
 <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png" />
 <link rel="manifest" href="site.webmanifest" />
 <link rel="icon" type="image/x-icon" href="favicon.ico" />
+<link rel="icon" type="image/png" sizes="192x192" href="android-chrome-192x192.png" />
+<link rel="icon" type="image/png" sizes="512x512" href="android-chrome-512x512.png" />
+<link rel="shortcut icon" href="favicon.ico" />
 
 <!-- SEO Meta Tags -->
 <meta name="description" content="Play RectBlox, a fun and addictive match-3 puzzle game. Combine colorful blocks, plan your strategy, and enjoy free online gameplay on mobile or desktop!">
@@ -253,10 +256,24 @@
     top: -1.2rem;
     left: 50%;
     transform: translateX(-50%);
-    font-size: 0.7rem;
-    color: #a8926f;
+    font-size: 0.75rem;
+    color: #6b4e3d;
+    background: #fffbea;
+    padding: 0.2rem 0.5rem;
+    border-radius: 4px;
+    box-shadow: 0 0 10px rgba(212, 165, 116, 0.5);
     pointer-events: none;
     animation: pulse 2s infinite;
+  }
+
+  .shuffle-highlight {
+    animation: shuffle-glow 1s infinite;
+  }
+
+  @keyframes shuffle-glow {
+    0% { box-shadow: 0 0 0 0 rgba(255, 215, 0, 0.4); transform: scale(1); }
+    50% { box-shadow: 0 0 20px 5px rgba(255, 215, 0, 0.9); transform: scale(1.05); }
+    100% { box-shadow: 0 0 0 0 rgba(255, 215, 0, 0.4); transform: scale(1); }
   }
 
   button {
@@ -956,7 +973,7 @@
       <div class="action-buttons">
         <button class="secondary-button" id="shuffleBtn">
           Reset Position
-          <div id="shuffleTip" class="shuffle-tip">Stuck? Try Reset Position!</div>
+          <div id="shuffleTip" class="shuffle-tip">👉 Stuck? Reset Position!</div>
         </button>
         <div class="level-info">Level <span id="level">1</span>: <span id="levelName">Easy Level</span></div>
         <button class="secondary-button" id="restartBtn">Restart</button>
@@ -1241,10 +1258,12 @@ function updateUI() {
 
 function showShuffleTip() {
   document.getElementById('shuffleTip').style.display = 'block';
+  document.getElementById('shuffleBtn').classList.add('shuffle-highlight');
 }
 
 function hideShuffleTip() {
   document.getElementById('shuffleTip').style.display = 'none';
+  document.getElementById('shuffleBtn').classList.remove('shuffle-highlight');
 }
 
 function nextLevel() {

--- a/itch.html
+++ b/itch.html
@@ -9,6 +9,9 @@
 <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png" />
 <link rel="manifest" href="site.webmanifest" />
 <link rel="icon" type="image/x-icon" href="favicon.ico" />
+<link rel="icon" type="image/png" sizes="192x192" href="android-chrome-192x192.png" />
+<link rel="icon" type="image/png" sizes="512x512" href="android-chrome-512x512.png" />
+<link rel="shortcut icon" href="favicon.ico" />
 
 <!-- SEO Meta Tags -->
 <meta name="description" content="Play RectBlox, a fun and addictive match-3 puzzle game. Combine colorful blocks, plan your strategy, and enjoy free online gameplay on mobile or desktop!">
@@ -230,10 +233,24 @@
     top: -1.2rem;
     left: 50%;
     transform: translateX(-50%);
-    font-size: 0.7rem;
-    color: #a8926f;
+    font-size: 0.75rem;
+    color: #6b4e3d;
+    background: #fffbea;
+    padding: 0.2rem 0.5rem;
+    border-radius: 4px;
+    box-shadow: 0 0 10px rgba(212, 165, 116, 0.5);
     pointer-events: none;
     animation: pulse 2s infinite;
+  }
+
+  .shuffle-highlight {
+    animation: shuffle-glow 1s infinite;
+  }
+
+  @keyframes shuffle-glow {
+    0% { box-shadow: 0 0 0 0 rgba(255, 215, 0, 0.4); transform: scale(1); }
+    50% { box-shadow: 0 0 20px 5px rgba(255, 215, 0, 0.9); transform: scale(1.05); }
+    100% { box-shadow: 0 0 0 0 rgba(255, 215, 0, 0.4); transform: scale(1); }
   }
 
   button {
@@ -850,7 +867,7 @@
     <div class="action-buttons">
       <button class="secondary-button" id="shuffleBtn">
         Reset Position
-        <div id="shuffleTip" class="shuffle-tip">Stuck? Try Reset Position!</div>
+        <div id="shuffleTip" class="shuffle-tip">👉 Stuck? Reset Position!</div>
       </button>
       <div class="level-info">Level <span id="level">1</span>: <span id="levelName">Easy Level</span></div>
       <button class="secondary-button" id="restartBtn">Restart</button>
@@ -1082,10 +1099,12 @@ function updateUI() {
 
 function showShuffleTip() {
   document.getElementById('shuffleTip').style.display = 'block';
+  document.getElementById('shuffleBtn').classList.add('shuffle-highlight');
 }
 
 function hideShuffleTip() {
   document.getElementById('shuffleTip').style.display = 'none';
+  document.getElementById('shuffleBtn').classList.remove('shuffle-highlight');
 }
 
 function nextLevel() {

--- a/privacy.html
+++ b/privacy.html
@@ -4,6 +4,14 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Privacy Policy - RectBlox</title>
+    <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png" />
+    <link rel="icon" type="image/png" sizes="192x192" href="android-chrome-192x192.png" />
+    <link rel="icon" type="image/png" sizes="512x512" href="android-chrome-512x512.png" />
+    <link rel="manifest" href="site.webmanifest" />
+    <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    <link rel="shortcut icon" href="favicon.ico" />
     <style>
         body {
             font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;

--- a/terms.html
+++ b/terms.html
@@ -4,6 +4,14 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Terms of Service - RectBlox</title>
+    <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png" />
+    <link rel="icon" type="image/png" sizes="192x192" href="android-chrome-192x192.png" />
+    <link rel="icon" type="image/png" sizes="512x512" href="android-chrome-512x512.png" />
+    <link rel="manifest" href="site.webmanifest" />
+    <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    <link rel="shortcut icon" href="favicon.ico" />
     <style>
         body {
             font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;


### PR DESCRIPTION
## Summary
- Make reset hint more visible with glowing animation
- Emphasize "Reset Position" tip after consecutive non-clearing moves across HTML variants
- Add high-resolution favicon links so search results display the site icon

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68903396dc64832c983a070722276580